### PR TITLE
fix: プリセット選択時にシェーダーパターンが上書きされるバグを修正

### DIFF
--- a/lib/interface/shader_config.dart
+++ b/lib/interface/shader_config.dart
@@ -60,14 +60,12 @@ class ShaderConfig {
   );
 
   static const ocean = ShaderConfig(
-    pattern: ShaderPattern.ripple,
     color1: Color(0xFF006994),
     color2: Color(0xFF00CED1),
     color3: Color(0xFF40E0D0),
   );
 
   static const fire = ShaderConfig(
-    pattern: ShaderPattern.vortex,
     color1: Color(0xFFFF4500),
     color2: Color(0xFFFF8C00),
     color3: Color(0xFFFFD700),
@@ -75,7 +73,6 @@ class ShaderConfig {
   );
 
   static const pastel = ShaderConfig(
-    pattern: ShaderPattern.plasma,
     color1: Color(0xFFFFB3BA),
     color2: Color(0xFFBAE1FF),
     color3: Color(0xFFBAFFBA),

--- a/lib/widget/control_panel_widget.dart
+++ b/lib/widget/control_panel_widget.dart
@@ -88,7 +88,7 @@ class _ControlPanelWidgetState extends State<ControlPanelWidget> {
         children: [
           _buildPatternDropdown(context, config),
           const SizedBox(height: _Style.sectionSpacing),
-          _buildPresetChips(context),
+          _buildPresetChips(context, config.pattern),
           const SizedBox(height: _Style.sectionSpacing),
           _buildSliderRow(
             label: 'Speed',
@@ -134,7 +134,7 @@ class _ControlPanelWidgetState extends State<ControlPanelWidget> {
     );
   }
 
-  Widget _buildPresetChips(BuildContext context) {
+  Widget _buildPresetChips(BuildContext context, ShaderPattern currentPattern) {
     return Wrap(
       spacing: _Style.chipSpacing,
       runSpacing: _Style.chipRunSpacing,
@@ -142,8 +142,10 @@ class _ControlPanelWidgetState extends State<ControlPanelWidget> {
           .map(
             (entry) => ActionChip(
               label: Text(entry.key),
-              onPressed: () =>
-                  ShaderProvider.updateConfig(context, entry.value),
+              onPressed: () => ShaderProvider.updateConfig(
+                context,
+                entry.value.copyWith(pattern: currentPattern),
+              ),
             ),
           )
           .toList(),

--- a/test/interface/shader_config_test.dart
+++ b/test/interface/shader_config_test.dart
@@ -84,5 +84,15 @@ void main() {
       expect(ShaderConfig.presets.containsKey('cool'), isTrue);
       expect(ShaderConfig.presets.containsKey('neon'), isTrue);
     });
+
+    test('全プリセットがデフォルトpattern(marble)を持つ', () {
+      for (final entry in ShaderConfig.presets.entries) {
+        expect(
+          entry.value.pattern,
+          ShaderPattern.marble,
+          reason: '${entry.key}プリセットがpatternを上書きしている',
+        );
+      }
+    });
   });
 }


### PR DESCRIPTION
ocean/fire/pastelプリセットからpattern指定を削除し、プリセット適用時に現在のpatternをcopyWithで保持するよう変更
