### PR TITLE
feat: カラーピッカーUIと2カラムレイアウト

### DIFF
--- a/lib/widget/control_panel_widget.dart
+++ b/lib/widget/control_panel_widget.dart
@@ -1,3 +1,4 @@
+import 'package:flex_color_picker/flex_color_picker.dart';
 import 'package:flutter/material.dart';
 
 import 'package:psychedelic_bg/interface/shader_config.dart';
@@ -12,7 +13,8 @@ abstract final class _Style {
   static const Color sliderLabelColor = Colors.white;
 
   // -- Dimensions --
-  static const double panelMaxWidth = 360;
+  static const double panelMaxWidth = 560;
+  static const double columnSpacing = 16;
   static const double buttonPadding = 16;
   static const double panelMargin = 16;
   static const double panelPadding = 16;
@@ -23,6 +25,7 @@ abstract final class _Style {
   static const double dropdownFontSize = 14;
   static const double sliderLabelWidth = 80;
   static const double sliderFontSize = 12;
+  static const double colorIndicatorSize = 32;
 
   // -- Typography --
   static const TextStyle dropdownText = TextStyle(
@@ -60,7 +63,7 @@ class _ControlPanelWidgetState extends State<ControlPanelWidget> {
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.end,
           children: [
-            if (_isOpen) Flexible(child: _buildPanel(context)),
+            if (_isOpen) _buildPanel(context),
             Padding(
               padding: const EdgeInsets.all(_Style.buttonPadding),
               child: FloatingActionButton(
@@ -82,36 +85,86 @@ class _ControlPanelWidgetState extends State<ControlPanelWidget> {
       margin: const EdgeInsets.symmetric(horizontal: _Style.panelMargin),
       padding: const EdgeInsets.all(_Style.panelPadding),
       decoration: _Style.panelDecoration,
-      child: SingleChildScrollView(
-        child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          _buildPatternDropdown(context, config),
-          const SizedBox(height: _Style.sectionSpacing),
-          _buildPresetChips(context, config.pattern),
-          const SizedBox(height: _Style.sectionSpacing),
-          _buildSliderRow(
-            label: 'Speed',
-            value: config.speed,
-            min: ShaderConfig.minSpeed,
-            max: ShaderConfig.maxSpeed,
-            onChanged: (v) => ShaderProvider.updateConfig(
-              context,
-              config.copyWith(speed: v),
+      child: IntrinsicHeight(
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Left column: pattern, presets, colors
+            Expanded(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildPatternDropdown(context, config),
+                  const SizedBox(height: _Style.sectionSpacing),
+                  _buildPresetChips(context, config.pattern),
+                  const SizedBox(height: _Style.sectionSpacing),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                    children: [
+                      Flexible(
+                        child: _buildColorRow(
+                            'Color 1', config.color1, (c) {
+                          ShaderProvider.updateConfig(
+                            context,
+                            config.copyWith(color1: c),
+                          );
+                        }),
+                      ),
+                      Flexible(
+                        child: _buildColorRow(
+                            'Color 2', config.color2, (c) {
+                          ShaderProvider.updateConfig(
+                            context,
+                            config.copyWith(color2: c),
+                          );
+                        }),
+                      ),
+                      Flexible(
+                        child: _buildColorRow(
+                            'Color 3', config.color3, (c) {
+                          ShaderProvider.updateConfig(
+                            context,
+                            config.copyWith(color3: c),
+                          );
+                        }),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
             ),
-          ),
-          _buildSliderRow(
-            label: 'Complexity',
-            value: config.complexity,
-            min: ShaderConfig.minComplexity,
-            max: ShaderConfig.maxComplexity,
-            onChanged: (v) => ShaderProvider.updateConfig(
-              context,
-              config.copyWith(complexity: v),
+            const SizedBox(width: _Style.columnSpacing),
+            // Right column: sliders
+            Expanded(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  _buildSliderRow(
+                    label: 'Speed',
+                    value: config.speed,
+                    min: ShaderConfig.minSpeed,
+                    max: ShaderConfig.maxSpeed,
+                    onChanged: (v) => ShaderProvider.updateConfig(
+                      context,
+                      config.copyWith(speed: v),
+                    ),
+                  ),
+                  _buildSliderRow(
+                    label: 'Complexity',
+                    value: config.complexity,
+                    min: ShaderConfig.minComplexity,
+                    max: ShaderConfig.maxComplexity,
+                    onChanged: (v) => ShaderProvider.updateConfig(
+                      context,
+                      config.copyWith(complexity: v),
+                    ),
+                  ),
+                ],
+              ),
             ),
-          ),
-        ],
+          ],
         ),
       ),
     );
@@ -151,6 +204,40 @@ class _ControlPanelWidgetState extends State<ControlPanelWidget> {
             ),
           )
           .toList(),
+    );
+  }
+
+  Widget _buildColorRow(
+    String label,
+    Color color,
+    ValueChanged<Color> onChanged,
+  ) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        GestureDetector(
+          onTap: () async {
+            final picked = await showColorPickerDialog(
+              context,
+              color,
+              pickersEnabled: const <ColorPickerType, bool>{
+                ColorPickerType.wheel: true,
+              },
+            );
+            onChanged(picked);
+          },
+          child: Container(
+            width: _Style.colorIndicatorSize,
+            height: _Style.colorIndicatorSize,
+            decoration: BoxDecoration(
+              color: color,
+              shape: BoxShape.circle,
+            ),
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(label, style: _Style.sliderLabel),
+      ],
     );
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -57,6 +57,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
+  flex_color_picker:
+    dependency: "direct main"
+    description:
+      name: flex_color_picker
+      sha256: a0979dd61f21b634717b98eb4ceaed2bfe009fe020ce8597aaf164b9eeb57aaa
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.8.0"
+  flex_seed_scheme:
+    dependency: transitive
+    description:
+      name: flex_seed_scheme
+      sha256: a3183753bbcfc3af106224bff3ab3e1844b73f58062136b7499919f49f3667e7
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -210,4 +226,4 @@ packages:
     version: "14.3.1"
 sdks:
   dart: ">=3.11.0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  flutter: ">=3.38.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  flex_color_picker: ^3.8.0
 
 dev_dependencies:
   flutter_test:

--- a/test/widget/control_panel_widget_test.dart
+++ b/test/widget/control_panel_widget_test.dart
@@ -18,7 +18,7 @@ void main() {
       manager.dispose();
     });
 
-    Widget buildTestWidget({Size size = const Size(400, 800)}) {
+    Widget buildTestWidget({Size size = const Size(800, 400)}) {
       return MaterialApp(
         home: MediaQuery(
           data: MediaQueryData(size: size),
@@ -120,6 +120,38 @@ void main() {
             w.max == ShaderConfig.maxComplexity,
       );
       expect(complexitySlider, findsOneWidget);
+    });
+
+    testWidgets('3つのカラーインジケータが表示される', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.tap(find.byIcon(Icons.tune));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Color 1'), findsOneWidget);
+      expect(find.text('Color 2'), findsOneWidget);
+      expect(find.text('Color 3'), findsOneWidget);
+    });
+
+    testWidgets('カラーインジケータがconfigの色を反映する', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.tap(find.byIcon(Icons.tune));
+      await tester.pumpAndSettle();
+
+      final indicators = tester.widgetList<Container>(
+        find.byWidgetPredicate(
+          (w) =>
+              w is Container &&
+              w.decoration is BoxDecoration &&
+              (w.decoration as BoxDecoration).shape == BoxShape.circle,
+        ),
+      );
+
+      final colors = indicators
+          .map((c) => (c.decoration as BoxDecoration?)?.color)
+          .toList();
+      expect(colors, contains(ShaderConfig.defaultColor1));
+      expect(colors, contains(ShaderConfig.defaultColor2));
+      expect(colors, contains(ShaderConfig.defaultColor3));
     });
 
     testWidgets('右下に配置される', (tester) async {


### PR DESCRIPTION
## Summary
- `flex_color_picker`パッケージ追加によるcolor1/color2/color3の動的変更UI
- 横画面対応の2カラムレイアウト（左: パターン+プリセット+カラー / 右: スライダー）
- スクロール不要なコンパクトなパネル設計

## Test plan
- [x] mise run test で全テスト通過
- [x] Android実機でカラーピッカーダイアログ動作確認
- [x] 横画面でパネルがオーバーフローしないことを確認